### PR TITLE
Separation of concerns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { fetchWeatherData } from "./services/weather-api";
 import { ForecastWrapper } from "./UI/forecast-wrapper";
 import { ForecastToday } from "./components/forecast-today";
-import { ForecastList } from "./components/forecast-list";
+import { ForecastList as ForecastListItem } from "./components/forecast-list";
 import { ZipForm } from "./components/zip-form";
 import { ErrorItem } from "./components/error-item";
 
@@ -45,16 +45,18 @@ function App() {
     getWeather();
   }, []);
 
+  const [today, ...week] = weather;
+
   return (
     <div className="App">
       <ZipForm value={zip} onChange={zipHandler} onClick={submitHandler} />
 
       {error ? <ErrorItem errorMessage={error} /> : ""}
 
-      <ForecastToday items={weather} />
+      {today ? <ForecastToday item={today} /> : ""}
 
       <ForecastWrapper>
-        <ForecastList items={weather} />
+        {week.map(item => <ForecastListItem key={item.key} item={item} />)}
       </ForecastWrapper>
     </div>
   );

--- a/src/components/forecast-list.js
+++ b/src/components/forecast-list.js
@@ -3,11 +3,11 @@ import { ReactComponent as Umbrella } from "../images/umbrella-solid.svg";
 import { ReactComponent as HighTemp } from "../images/temperature-full-solid.svg";
 import { ReactComponent as LowTemp } from "../images/temperature-empty-solid.svg";
 
-export const ForecastList = ({ items }) => {
+export const ForecastList = ({ item }) => {
   // Map over weather API repsonse data to build
   // responsive elements.
-  return items.slice(1).map((item) => (
-    <div className={styles["forecast-day"]} key={item.key}>
+  return (
+    <div className={styles["forecast-day"]}>
       <div className={styles["forecast-image-container"]}>
         <img
           className={styles["forecast-image"]}
@@ -52,5 +52,5 @@ export const ForecastList = ({ items }) => {
         </div>
       </div>
     </div>
-  ));
+  );
 };

--- a/src/components/forecast-today.js
+++ b/src/components/forecast-today.js
@@ -3,13 +3,13 @@ import { ReactComponent as Umbrella } from "../images/umbrella-solid.svg";
 import { ReactComponent as HighTemp } from "../images/temperature-full-solid.svg";
 import { ReactComponent as LowTemp } from "../images/temperature-empty-solid.svg";
 
-export const ForecastToday = ({ items }) => {
+export const ForecastToday = ({ item }) => {
   // Map over weather API repsonse data for
   // first element to build responsive elements
   // for today's weather.
 
-  return items.slice(0, 1).map((item) => (
-    <div className={styles["today-container"]} key={item.key}>
+  return (
+    <div className={styles["today-container"]}>
       <div className={styles["forecast-today"]}>
         <div className={styles["location"]}>
           <h2>Weather Forecast</h2>
@@ -62,5 +62,5 @@ export const ForecastToday = ({ items }) => {
         </div>
       </div>
     </div>
-  ));
+  );
 };


### PR DESCRIPTION
Refactored ForecastToday and ForecastList to only accept one `item`, and have the App pass them in. ForecastList can be renamed to ForecastListItem but I wanted to reduce the changeset so it wasn't confusing.

This change makes the components "dumber" and App can also assign the keys itself when mapping over the week.

Unable to test due to the API key not being on my machine.